### PR TITLE
add hash field for schema table, and use it for queries and index

### DIFF
--- a/src/core/models/schemaModel.ts
+++ b/src/core/models/schemaModel.ts
@@ -1,6 +1,7 @@
 export class SchemaDBModel {
   id!: number
   typeDefs!: string
+  hash!: string
   isActive?: boolean
   createdAt!: Date
   updatedAt?: Date

--- a/src/core/repositories/SchemaRepository.ts
+++ b/src/core/repositories/SchemaRepository.ts
@@ -23,11 +23,11 @@ export default class SchemaRepository {
   }
   findFirst({
     graphName,
-    typeDefs,
+    typeDefsHash,
     serviceName,
   }: {
     graphName: string
-    typeDefs: string
+    typeDefsHash: string
     serviceName: string
   }) {
     const knex = this.knex
@@ -46,7 +46,8 @@ export default class SchemaRepository {
         [GraphDBModel.fullName('name')]: graphName,
         [ServiceDBModel.fullName('isActive')]: true,
         [ServiceDBModel.fullName('name')]: serviceName,
-        [SchemaDBModel.fullName('typeDefs')]: typeDefs,
+        [SchemaDBModel.fullName('hash')]: typeDefsHash,
+
       })
       .select(`${table}.*`)
       .first<SchemaDBModel | undefined>()

--- a/src/core/shared-schemas.ts
+++ b/src/core/shared-schemas.ts
@@ -3,7 +3,7 @@ import S from 'fluent-json-schema'
 export const serviceName = S.string().minLength(1).maxLength(100).pattern('[a-zA-Z_\\-0-9]+')
 export const graphName = S.string().minLength(1).maxLength(100).pattern('[a-zA-Z_\\-0-9]+')
 export const version = S.string().minLength(1).maxLength(100).pattern('[a-zA-Z_\\-0-9]+')
-export const typeDefs = S.string().minLength(1).maxLength(10000)
+export const typeDefs = S.string().minLength(1).maxLength(20000)
 export const schemaId = S.integer().minimum(1)
 export const document = S.string().minLength(1).maxLength(10000)
 export const routingUrl = S.string().minLength(1).maxLength(10000).format(S.FORMATS.URI)

--- a/src/migrations/20210504193054_initial_schema.ts
+++ b/src/migrations/20210504193054_initial_schema.ts
@@ -53,6 +53,7 @@ export async function up(knex: Knex): Promise<void> {
       table.increments(SchemaDBModel.field('id')).primary()
 
       table.text(SchemaDBModel.field('typeDefs'))
+      table.string(SchemaDBModel.field('hash')).notNullable()
       table.boolean(SchemaDBModel.field('isActive')).notNullable().defaultTo(true)
       table
         .timestamp(SchemaDBModel.field('createdAt'), { useTz: true })
@@ -77,7 +78,7 @@ export async function up(knex: Knex): Promise<void> {
         .index()
 
       table.index([SchemaDBModel.field('isActive')])
-      table.index([SchemaDBModel.field('typeDefs')])
+      table.index([SchemaDBModel.field('hash')])
     })
     .createTable(SchemaTagDBModel.table, (table) => {
       table.increments(SchemaTagDBModel.field('id')).primary()


### PR DESCRIPTION
Hi, I've played around with `graphql-registry` and found several cases where my schema can not be pushed to registry.

Problem:

1. My schema is quite large, 14 000 length text, so validation fails.
2. Also, postgres can not create index on that large schema.

Solution:
- increase validation length to 20000 (but still, maybe this must be configured somehow)
- add new `hash` field, which is a hash of whole `typeDefs`